### PR TITLE
Bump Vaadin to 25.1.1 + migrate to browserless-test-junit6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,13 @@
 
     <properties>
         <java.version>21</java.version>
-        <vaadin.version>25.0.7</vaadin.version>
+        <vaadin.version>25.1.1</vaadin.version>
     </properties>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,12 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-testbench-junit5</artifactId>
+            <artifactId>browserless-test-junit6</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-junit6</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/example/application/views/helloworld/HelloWorldViewTest.java
+++ b/src/test/java/com/example/application/views/helloworld/HelloWorldViewTest.java
@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.vaadin.browserless.SpringBrowserlessTest;
 import com.vaadin.flow.component.notification.Notification;
-import com.vaadin.testbench.unit.SpringUIUnitTest;
 
 @SpringBootTest
-public class HelloWorldViewTest extends SpringUIUnitTest {
+public class HelloWorldViewTest extends SpringBrowserlessTest {
 
     @Test
     public void setText_clickButton_notificationIsShown() {
@@ -21,7 +21,7 @@ public class HelloWorldViewTest extends SpringUIUnitTest {
 
         // Notification isn't referenced in the view so we need to use the component
         // query API to find the notification that opened
-        Notification notification = $(Notification.class).first();
+        Notification notification = $(Notification.class).single();
         Assertions.assertEquals("Hello Test", test(notification).getText());
     }
 


### PR DESCRIPTION
## Summary

Alternative to #45. Bumps the same three dependencies and additionally fixes the `testCompile` failure that #45 hits.

- `spring-boot-starter-parent` 4.0.4 → 4.0.5
- `vaadin-bom` 25.0.7 → 25.1.1
- `vaadin-maven-plugin` 25.0.7 → 25.1.1
- Migrates `HelloWorldViewTest` to the new browserless-testing API

## Why the test change is needed

Vaadin 25.1 reorganized the UI unit-testing API:

| Old (≤ 25.0)                                                | New (25.1+)                                            |
|-------------------------------------------------------------|--------------------------------------------------------|
| `vaadin-testbench-unit-junit5` (transitive via `vaadin-testbench-junit5`) | `browserless-test-junit6`                              |
| `com.vaadin.testbench.unit.SpringUIUnitTest`                | `com.vaadin.browserless.SpringBrowserlessTest`         |
| `ComponentQuery#first()` (deprecated)                       | `ComponentQuery#single()`                              |

Without these changes, the old import (`com.vaadin.testbench.unit`) no longer resolves and the build fails at `maven-compiler-plugin:testCompile` — exactly what CI shows on #45.

## Test plan
- [x] `./mvnw test` → `Tests run: 1, Failures: 0, Errors: 0. BUILD SUCCESS`
- [ ] CI green on this PR
- [ ] Optional: `./mvnw verify -Pit` end-to-end check

🤖 Generated with [Claude Code](https://claude.com/claude-code)